### PR TITLE
fix(#21): Fix infinite save loop, VEHICLE_TRADE_IN credit event, and vehiclesFound statistic

### DIFF
--- a/src/data/CreditSystem.lua
+++ b/src/data/CreditSystem.lua
@@ -891,6 +891,9 @@ CreditHistory.EVENT_TYPES = {
     PAYMENT_MINIMUM = { name = "Minimum Payment", change = 0 },
     PAYMENT_STANDARD = { name = "Standard Payment", change = 2 },
     PAYMENT_EXTRA = { name = "Extra Payment", change = 3 },
+
+    -- Trade-in / sale events
+    VEHICLE_TRADE_IN = { name = "Vehicle Trade-In", change = 2 },     -- Small positive: responsible asset management
 }
 
 -- Maximum history entries per farm (for performance)

--- a/src/managers/FinanceManager.lua
+++ b/src/managers/FinanceManager.lua
@@ -91,7 +91,10 @@ function FinanceManager:getStatistics(farmId)
             negotiationsWon = 0,            -- Accepted at offered price
             negotiationsCountered = 0,      -- Accepted at counter price
             negotiationsRejected = 0,       -- Walked away or paid full
-            totalNegotiationSavings = 0     -- Money saved through negotiation
+            totalNegotiationSavings = 0,    -- Money saved through negotiation
+
+            -- v2.15.2: Used vehicle search tracking (fix: was missing, caused Unknown statistic warns)
+            vehiclesFound = 0               -- Total vehicles found by agent searches
         }
     end
     return self.statisticsByFarm[farmId]

--- a/vehicles/ServiceTruck.lua
+++ b/vehicles/ServiceTruck.lua
@@ -52,15 +52,22 @@ function ServiceTruck.initSpecialization()
     schema:register(XMLValueType.INT, "vehicle.serviceTruck.fillUnits#oil", "Fill unit index for oil", 3)
     schema:register(XMLValueType.INT, "vehicle.serviceTruck.fillUnits#hydraulic", "Fill unit index for hydraulic", 4)
 
-    -- Savegame schema
-    local schemaSavegame = Vehicle.xmlSchemaSavegame
-    schemaSavegame:register(XMLValueType.BOOL, "vehicles.vehicle(?).serviceTruck#isRestoring", "Is currently restoring a vehicle")
-    schemaSavegame:register(XMLValueType.INT, "vehicles.vehicle(?).serviceTruck#targetVehicleId", "ID of vehicle being restored")
-    schemaSavegame:register(XMLValueType.STRING, "vehicles.vehicle(?).serviceTruck#component", "Component being restored")
-    schemaSavegame:register(XMLValueType.FLOAT, "vehicles.vehicle(?).serviceTruck#startReliability", "Reliability when started")
-    schemaSavegame:register(XMLValueType.FLOAT, "vehicles.vehicle(?).serviceTruck#progress", "Current progress 0-1")
-
     schema:setXMLSpecializationType()
+
+    -- Fix #21: Savegame schema MUST be registered outside the setXMLSpecializationType scope.
+    -- Pattern from UsedPlusMaintenance.initSpecialization (working reference).
+    -- Keys must include the mod name prefix (FS25_UsedPlus.ServiceTruck) to match what
+    -- the game passes as `key` to saveToXMLFile — previously used bare "serviceTruck"
+    -- which caused "Path not registered" validation errors on every save, locking the
+    -- game in an infinite saving loop.
+    -- Child element notation (dot) is used throughout to be consistent with schema validation.
+    local schemaSavegame = Vehicle.xmlSchemaSavegame
+    local saveKey = "vehicles.vehicle(?)." .. ServiceTruck.MOD_NAME .. ".ServiceTruck"
+    schemaSavegame:register(XMLValueType.BOOL,   saveKey .. ".isRestoring",      "Is currently restoring a vehicle", false)
+    schemaSavegame:register(XMLValueType.INT,    saveKey .. ".targetVehicleId",  "ID of vehicle being restored", 0)
+    schemaSavegame:register(XMLValueType.STRING, saveKey .. ".component",        "Component being restored", "")
+    schemaSavegame:register(XMLValueType.FLOAT,  saveKey .. ".startReliability", "Reliability when started", 0)
+    schemaSavegame:register(XMLValueType.FLOAT,  saveKey .. ".progress",         "Current progress 0-1", 0)
 end
 
 function ServiceTruck.registerFunctions(vehicleType)
@@ -89,6 +96,7 @@ function ServiceTruck.registerEventListeners(vehicleType)
     SpecializationUtil.registerEventListener(vehicleType, "onUpdate", ServiceTruck)
     SpecializationUtil.registerEventListener(vehicleType, "onReadStream", ServiceTruck)
     SpecializationUtil.registerEventListener(vehicleType, "onWriteStream", ServiceTruck)
+    SpecializationUtil.registerEventListener(vehicleType, "saveToXMLFile", ServiceTruck)  -- Fix #21: was missing, caused schema validation errors on every save
     SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", ServiceTruck)
 end
 
@@ -145,12 +153,13 @@ function ServiceTruck:onLoad(savegame)
 
     -- Load from savegame
     if savegame ~= nil and savegame.xmlFile ~= nil then
-        local key = savegame.key .. ".serviceTruck"
-        spec.isRestoring = savegame.xmlFile:getValue(key .. "#isRestoring", false)
-        spec.savedTargetId = savegame.xmlFile:getValue(key .. "#targetVehicleId")
-        spec.savedComponent = savegame.xmlFile:getValue(key .. "#component")
-        spec.savedStartReliability = savegame.xmlFile:getValue(key .. "#startReliability")
-        spec.savedProgress = savegame.xmlFile:getValue(key .. "#progress")
+        -- Fix #21: key must include MOD_NAME prefix to match schema registration path
+        local key = savegame.key .. "." .. ServiceTruck.MOD_NAME .. ".ServiceTruck"
+        spec.isRestoring = savegame.xmlFile:getValue(key .. ".isRestoring", false)
+        spec.savedTargetId = savegame.xmlFile:getValue(key .. ".targetVehicleId")
+        spec.savedComponent = savegame.xmlFile:getValue(key .. ".component")
+        spec.savedStartReliability = savegame.xmlFile:getValue(key .. ".startReliability")
+        spec.savedProgress = savegame.xmlFile:getValue(key .. ".progress")
     end
 
     UsedPlus.logInfo("ServiceTruck loaded - Long-term vehicle restoration ready")
@@ -181,7 +190,8 @@ end
 function ServiceTruck:saveToXMLFile(xmlFile, key, usedModNames)
     local spec = self[SPEC_NAME]
 
-    xmlFile:setValue(key .. "#isRestoring", spec.isRestoring)
+    -- Fix #21: Use dot (child element) notation to match registered schema paths
+    xmlFile:setValue(key .. ".isRestoring", spec.isRestoring)
 
     if spec.restorationData ~= nil then
         local targetId = nil
@@ -189,16 +199,16 @@ function ServiceTruck:saveToXMLFile(xmlFile, key, usedModNames)
             targetId = spec.restorationData.targetVehicle.id
         end
         if targetId ~= nil then
-            xmlFile:setValue(key .. "#targetVehicleId", targetId)
+            xmlFile:setValue(key .. ".targetVehicleId", targetId)
         end
         if spec.restorationData.component ~= nil then
-            xmlFile:setValue(key .. "#component", spec.restorationData.component)
+            xmlFile:setValue(key .. ".component", spec.restorationData.component)
         end
         if spec.restorationData.startReliability ~= nil then
-            xmlFile:setValue(key .. "#startReliability", spec.restorationData.startReliability)
+            xmlFile:setValue(key .. ".startReliability", spec.restorationData.startReliability)
         end
         if spec.restorationData.progress ~= nil then
-            xmlFile:setValue(key .. "#progress", spec.restorationData.progress)
+            xmlFile:setValue(key .. ".progress", spec.restorationData.progress)
         end
     end
 end


### PR DESCRIPTION
Fixes #21

## Summary

Fixes the infinite saving screen and related warnings reported in #21. Three bugs identified from the log file analysis.

---

## Bug 1 — Infinite Saving Screen (Critical) `vehicles/ServiceTruck.lua`

The game validates all XML paths before writing during a save. Three separate problems in `ServiceTruck.initSpecialization()` and `saveToXMLFile()` caused this validation to fail on **every single save**, locking the game in an infinite `updateSaving` loop:

### 1a — Wrong schema key path
The savegame schema was registering paths under `vehicles.vehicle(?).serviceTruck#isRestoring` (bare, no mod name prefix). The game builds the save key as `vehicles.vehicle(N).FS25_UsedPlus.ServiceTruck` — so the registered path never matched, causing the `Path not registered` error seen in the log.

**Fixed:** Schema now registers `vehicles.vehicle(?).FS25_UsedPlus.ServiceTruck.isRestoring` — matching the pattern used correctly by `UsedPlusMaintenance`.

### 1b — Schema registered inside `setXMLSpecializationType` scope
`schemaSavegame` registrations were placed between `schema:setXMLSpecializationType("ServiceTruck")` and `schema:setXMLSpecializationType()`. Savegame schema must be registered **outside** this scope (as `UsedPlusMaintenance` correctly does).

**Fixed:** Moved schemaSavegame block after the closing `schema:setXMLSpecializationType()` call.

### 1c — `saveToXMLFile` event listener was never registered
`registerEventListeners` was missing the `saveToXMLFile` registration entirely. The `saveToXMLFile` function existed but was never called by the game.

**Fixed:** Added `SpecializationUtil.registerEventListener(vehicleType, "saveToXMLFile", ServiceTruck)`.

### 1d — Attribute (`#`) vs child element (`.`) notation mismatch
`onLoad` and `saveToXMLFile` were using `#` (XML attribute) notation while the schema registered child elements. Normalised all paths to use `.` (dot) notation throughout.

---

## Bug 2 — `Unknown credit event type: VEHICLE_TRADE_IN` `src/data/CreditSystem.lua`

`VEHICLE_TRADE_IN` was not present in `CreditHistory.EVENT_TYPES`, causing a warning on every trade-in during vehicle purchase and the event being silently dropped.

**Fixed:** Added `VEHICLE_TRADE_IN = { name = "Vehicle Trade-In", change = 2 }` to the EVENT_TYPES table.

---

## Bug 3 — `Unknown statistic: vehiclesFound` `src/managers/FinanceManager.lua`

`VehicleSearchSystem` calls `g_financeManager:incrementStatistic(farmId, "vehiclesFound", 1)` when an agent search succeeds, but `vehiclesFound` was not initialised in the default statistics table in `getStatistics()`, causing a warning and the stat being lost.

**Fixed:** Added `vehiclesFound = 0` to the default statistics table.

---

## Files Changed

| File | Change |
|------|--------|
| `vehicles/ServiceTruck.lua` | Fix schema path, scope, missing listener, and `#`→`.` notation |
| `src/data/CreditSystem.lua` | Add `VEHICLE_TRADE_IN` to `EVENT_TYPES` |
| `src/managers/FinanceManager.lua` | Add `vehiclesFound` to default statistics |